### PR TITLE
Port from failure to anyhow/thiserror, add passthrough

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ void = "1.0.2"
 downcast-rs = "1.1.1"
 weak-table = "0.2.3"
 url = "2.1.0"
+thiserror = "1.0.9"
+anyhow = "1.0.26"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.54", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ default = ["cbor", "json", "bincode"]
 [dependencies]
 futures = { version = "0.3.1", features = ["thread-pool"] }
 serde = { version = "1.0.101", features = ["derive"] }
-failure = "0.1.5"
 erased-serde = "0.3.9"
 serde_json = { version = "1.0.41", optional = true }
 serde_cbor = "0.10.2"

--- a/examples/function_stream.rs
+++ b/examples/function_stream.rs
@@ -6,7 +6,7 @@ use vessels::{
     log, OnTo,
 };
 
-use failure::Error;
+use anyhow::Error;
 
 use futures::{stream::iter, StreamExt};
 

--- a/src/channel/id_channel/mod.rs
+++ b/src/channel/id_channel/mod.rs
@@ -12,7 +12,6 @@ use core::{
     marker::PhantomData,
     pin::Pin,
 };
-use failure::Fail;
 use futures::{
     channel::mpsc::{unbounded, SendError, UnboundedReceiver, UnboundedSender},
     future::ok,

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -6,16 +6,14 @@ use crate::{
     Kind,
 };
 
-use core::{
-    fmt::{self, Display, Formatter},
-    marker::Unpin,
-};
-use failure::{Error, Fail};
+use anyhow::Error;
+use core::fmt::{self, Display, Formatter};
 use futures::{Sink, Stream};
 use serde::{
     de::{DeserializeOwned, DeserializeSeed},
     Deserialize, Serialize,
 };
+use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, Copy)]
 #[repr(transparent)]
@@ -32,8 +30,8 @@ pub trait Fork: Sync + Send + 'static {
     fn get_fork<K: Kind>(&self, fork_ref: ForkHandle) -> Fallible<K, K::ConstructError>;
 }
 
-#[derive(Debug, Fail)]
-pub struct ChannelError(#[fail(cause)] pub(crate) Error);
+#[derive(Debug, Error)]
+pub struct ChannelError(#[source] pub(crate) Error);
 
 impl Display for ChannelError {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/src/core/hal/network/mod.rs
+++ b/src/core/hal/network/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 use anyhow::Error;
-use failure::Fail;
 use futures::{future::ready, lock::Mutex, FutureExt, Sink, StreamExt};
 use std::{net::SocketAddr, sync::Arc};
 use thiserror::Error;
@@ -16,14 +15,14 @@ use url::Url;
 #[object]
 pub trait Peer {}
 
-#[derive(Fail, Debug, Kind)]
+#[derive(Error, Debug, Kind)]
 pub enum ConnectError {
-    #[fail(display = "connection failed: {}", _0)]
-    Connect(#[cause] Error),
-    #[fail(display = "construct failed: {}", _0)]
-    Construct(#[cause] Error),
-    #[fail(display = "underlying transport failed: {}", _0)]
-    Transport(#[cause] Error),
+    #[error("connection failed: `{0}`")]
+    Connect(#[source] Error),
+    #[error("construct failed: `{0}`")]
+    Construct(#[source] Error),
+    #[error("underlying transport failed: `{0}`")]
+    Transport(#[source] Error),
 }
 
 impl FromTransportError for ConnectError {
@@ -32,10 +31,10 @@ impl FromTransportError for ConnectError {
     }
 }
 
-#[derive(Fail, Debug, Kind)]
-#[fail(display = "listening failed: {}", cause)]
+#[derive(Error, Debug, Kind)]
+#[error("listening failed: {cause}")]
 pub struct ListenError {
-    #[fail(cause)]
+    #[source]
     cause: Error,
 }
 

--- a/src/core/hal/network/web.rs
+++ b/src/core/hal/network/web.rs
@@ -2,7 +2,6 @@ use super::{ConnectError, ConnectionError, RawClient};
 
 use crate::{core::spawn, kind::Future, kind::SinkStream, SyncSendAssert};
 
-use failure::Fail;
 use futures::{
     channel::{
         mpsc::{unbounded, UnboundedReceiver},
@@ -12,13 +11,14 @@ use futures::{
 };
 use js_sys::Uint8Array;
 use url::Url;
+use thiserror::Error;
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{BinaryType, MessageEvent, WebSocket};
 
 pub(crate) struct Client;
 
-#[derive(Fail, Debug)]
-#[fail(display = "the target port is being blocked")]
+#[derive(Error, Debug)]
+#[error("the target port is being blocked")]
 pub struct SecurityError;
 
 impl RawClient for Client {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,7 +2,6 @@ use alloc::sync::Arc;
 use anyhow::Error;
 #[cfg(target_arch = "wasm32")]
 use core::any::Any;
-use failure::Fail;
 use futures::{lock, SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use std::{collections::HashMap, sync::Mutex};
@@ -27,8 +26,8 @@ pub mod orchestrator;
 #[doc(hidden)]
 pub type Constructor<T> = Box<dyn FnOnce(Handle) -> Infallible<T> + Send + Sync>;
 
-#[derive(Fail, Debug, Kind)]
-#[fail(display = "{} is unimplemented on this target", feature)]
+#[derive(Error, Debug, Kind)]
+#[error("{feature} is unimplemented on this target")]
 pub struct UnimplementedError {
     feature: String,
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 use anyhow::Error;
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", feature = "core"))]
 use core::any::Any;
 use futures::{lock, SinkExt, StreamExt};
 use lazy_static::lazy_static;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,11 +1,12 @@
 use alloc::sync::Arc;
-#[cfg(any(feature = "core", target_arch = "wasm32"))]
+use anyhow::Error;
+#[cfg(target_arch = "wasm32")]
 use core::any::Any;
-use core::fmt::{self, Display, Formatter};
-use failure::{Error, Fail};
+use failure::Fail;
 use futures::{lock, SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use std::{collections::HashMap, sync::Mutex};
+use thiserror::Error;
 
 use crate::{
     channel::IdChannel,
@@ -32,28 +33,16 @@ pub struct UnimplementedError {
     feature: String,
 }
 
-#[derive(Fail, Debug, Kind)]
+#[derive(Error, Debug, Kind)]
 pub enum CoreError {
+    #[error("feature unavailable or unregistered")]
     Unavailable,
-    Unimplemented(#[fail(cause)] UnimplementedError),
-    Construct(#[fail(cause)] Error),
-    Transport(#[fail(cause)] Error),
-}
-
-impl Display for CoreError {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        use CoreError::{Construct, Transport, Unavailable, Unimplemented};
-        write!(
-            formatter,
-            "{}",
-            match self {
-                Unavailable => "this feature is unavailable or unregistered".to_owned(),
-                Unimplemented(feature) => format!("{}", feature),
-                Construct(e) => format!("handle transfer failed: {}", e),
-                Transport(e) => format!("underlying transport failed: {}", e),
-            }
-        )
-    }
+    #[error("`{0}`")]
+    Unimplemented(#[source] UnimplementedError),
+    #[error("`handle transfer failed: {0}`")]
+    Construct(#[source] Error),
+    #[error("`underlying transport failed: {0}`")]
+    Transport(#[source] Error),
 }
 
 impl FromTransportError for CoreError {

--- a/src/core/orchestrator/mod.rs
+++ b/src/core/orchestrator/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 
 use anyhow::Error;
 use core::marker::PhantomData;
-use failure::Fail;
 use futures::SinkExt;
 #[cfg(feature = "core")]
 use futures::StreamExt;
@@ -43,8 +42,8 @@ impl<T: Kind> Module<T> {
 #[kind(using::Serde)]
 pub(crate) struct LocalModule(pub(crate) Checksum);
 
-#[derive(Fail, Debug, Kind)]
-#[fail(display = "compile failed: {}", cause)]
+#[derive(Error, Debug, Kind)]
+#[error("compile failed: {cause}")]
 pub struct CompileError {
     cause: Error,
 }

--- a/src/core/orchestrator/mod.rs
+++ b/src/core/orchestrator/mod.rs
@@ -11,12 +11,14 @@ use crate::{
     Kind,
 };
 
+use anyhow::Error;
 use core::marker::PhantomData;
-use failure::{Error, Fail};
+use failure::Fail;
 use futures::SinkExt;
 #[cfg(feature = "core")]
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "core"))]
 mod native;
@@ -65,8 +67,8 @@ trait OrchestratorInner {
 #[derive(Kind)]
 pub struct Orchestrator(Shared<dyn OrchestratorInner>);
 
-#[derive(Fail, Debug, Kind)]
-#[fail(display = "instantiate failed: {}", cause)]
+#[derive(Error, Debug, Kind)]
+#[error("instantiate failed: {cause}")]
 pub struct InstantiateError {
     cause: Error,
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -28,9 +28,10 @@ use crate::{
 
 use serde::{de::DeserializeSeed, Serialize};
 
-use core::fmt::{Debug, Display, Formatter};
+use core::fmt::{self, Debug, Formatter};
+use std::error::Error;
 
-use failure::Fail;
+use thiserror::Error;
 
 pub trait UniformStreamSink<T>: ISink<T> + IStream<Item = T> {}
 
@@ -44,7 +45,7 @@ pub trait Format {
     /// binary formats and `String` for those of a human-readable nature.
     type Representation;
     /// The failure condition of this format. This may be encountered during deserialization.
-    type Error: Fail;
+    type Error: Error + Sync + Send + 'static;
 
     /// Serializes the provided item.
     fn serialize<T: Serialize>(item: T) -> Self::Representation
@@ -62,6 +63,8 @@ pub trait Format {
 
 pub trait ApplyEncode<'de>:
     Sized + UniformStreamSink<<Self as Context<'de>>::Item> + Context<'de>
+where
+    <Self as ISink<<Self as Context<'de>>::Item>>::Error: Error + 'static,
 {
     fn encode<F: Format + Encode<'de, Self>>(self) -> <F as Encode<'de, Self>>::Output;
 }
@@ -69,6 +72,7 @@ pub trait ApplyEncode<'de>:
 impl<'de, T> ApplyEncode<'de> for T
 where
     T: UniformStreamSink<<Self as Context<'de>>::Item> + Context<'de>,
+    <T as ISink<<Self as Context<'de>>::Item>>::Error: Error + 'static,
 {
     fn encode<F: Format + Encode<'de, Self>>(self) -> <F as Encode<'de, Self>>::Output {
         <F as Encode<_>>::encode(self)
@@ -82,7 +86,7 @@ pub trait ApplyDecode<'de, K: Kind> {
     where
         Self: UniformStreamSink<F::Representation> + Sync + Send + Sized + 'static,
         F::Representation: Clone + Sync + Send + 'static,
-        <Self as ISink<F::Representation>>::Error: Fail,
+        <Self as ISink<F::Representation>>::Error: Error + Sync + Send + 'static,
         T::Item: Sync + Send + 'static;
 }
 
@@ -93,7 +97,7 @@ impl<'de, U, K: Kind> ApplyDecode<'de, K> for U {
     where
         Self: UniformStreamSink<F::Representation> + Sync + Send + Sized + 'static,
         F::Representation: Clone + Sync + Send,
-        <Self as ISink<F::Representation>>::Error: Fail,
+        <Self as ISink<F::Representation>>::Error: Error + Sync + Send + 'static,
         T::Item: Sync + Send,
     {
         <F as Decode<'de, Self, K>>::decode::<T>(self)
@@ -102,6 +106,8 @@ impl<'de, U, K: Kind> ApplyDecode<'de, K> for U {
 
 pub trait Decode<'de, C: UniformStreamSink<<Self as Format>::Representation> + 'static, K: Kind>:
     Format
+where
+    C::Error: 'static,
 {
     type Output: IFuture<Output = Result<K, K::ConstructError>>;
 
@@ -112,6 +118,8 @@ pub trait Decode<'de, C: UniformStreamSink<<Self as Format>::Representation> + '
 
 pub trait Encode<'de, C: UniformStreamSink<<C as Context<'de>>::Item> + Context<'de>>:
     Format + Sized
+where
+    <C as ISink<<C as Context<'de>>::Item>>::Error: Error + 'static,
 {
     type Output: IStream<Item = <Self as Format>::Representation>
         + ISink<Self::Representation, Error = EncodeError<Self, <C as Context<'de>>::Item, C>>;
@@ -127,7 +135,7 @@ impl<
     > Decode<'de, C, K> for T
 where
     Self::Representation: Sync + Send + Clone,
-    <C as ISink<<Self as Format>::Representation>>::Error: Fail,
+    <C as ISink<<Self as Format>::Representation>>::Error: Error + Sync + Send + 'static,
 {
     type Output = Fallible<K, K::ConstructError>;
 
@@ -167,51 +175,37 @@ where
     }
 }
 
-pub enum EncodeError<T: Format, I, S: ISink<I>> {
-    Format(T::Error),
-    Sink(S::Error),
-}
-
-impl<I: 'static, T: Format + 'static, S: ISink<I> + 'static> Fail for EncodeError<T, I, S>
+#[derive(Error)]
+pub enum EncodeError<T: Format, I, S: ISink<I>>
 where
-    T::Error: Fail,
-    S::Error: Fail,
+    S::Error: Error + 'static,
 {
-}
-
-impl<T: Format, I, S: ISink<I>> Display for EncodeError<T, I, S>
-where
-    T::Error: Fail,
-    S::Error: Fail,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        match *self {
-            EncodeError::Format(ref err) => {
-                write!(f, "Error occurred in deserialization `{}`", err)
-            }
-            EncodeError::Sink(ref err) => write!(f, "Error occurred in underlying sink `{}`", err),
-        }
-    }
+    #[error("`{0}`")]
+    Format(#[source] T::Error),
+    #[error("`{0}`")]
+    Sink(#[source] S::Error),
 }
 
 impl<T: Format, I, S: ISink<I>> Debug for EncodeError<T, I, S>
 where
-    T::Error: Fail,
-    S::Error: Fail,
+    S::Error: Error + 'static,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        match *self {
-            EncodeError::Format(ref err) => {
-                write!(f, "Error occurred in deserialization `{:?}`", err)
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                EncodeError::Format(e) => format!("Format ({:?})", e),
+                EncodeError::Sink(e) => format!("Sink ({:?})", e),
             }
-            EncodeError::Sink(ref err) => {
-                write!(f, "Error occurred in underlying sink `{:?}`", err)
-            }
-        }
+        )
     }
 }
 
-impl<T: Format, I, S: ISink<I>> EncodeError<T, I, S> {
+impl<T: Format, I, S: ISink<I>> EncodeError<T, I, S>
+where
+    S::Error: Error,
+{
     fn from_sink_error(err: S::Error) -> Self {
         EncodeError::Sink(err)
     }
@@ -228,7 +222,7 @@ impl<
 where
     T::Representation: Sync + Send + Clone,
     <C as Context<'de>>::Item: Sync + Send,
-    <C as ISink<<C as Context<'de>>::Item>>::Error: Fail,
+    <C as ISink<<C as Context<'de>>::Item>>::Error: Error + Sync + Send + 'static,
 {
     type Output = SinkStream<
         Self::Representation,

--- a/src/kind/array.rs
+++ b/src/kind/array.rs
@@ -6,11 +6,12 @@ use crate::{
 };
 
 use core::{mem::MaybeUninit, ptr};
-use failure::Fail;
 use futures::{
     future::{ok, try_join_all, Ready},
     FutureExt, SinkExt, StreamExt, TryFutureExt,
 };
+use std::error::Error;
+use thiserror::Error;
 use void::Void;
 
 use super::WrappedError;
@@ -37,11 +38,11 @@ impl<T: Unpin + Sync + Send + 'static> Kind for [T; 0] {
     }
 }
 
-#[derive(Fail, Debug)]
-pub enum ArrayError<T: Fail> {
-    #[fail(display = "{}", _0)]
-    Construct(#[fail(cause)] T),
-    #[fail(display = "expected {} elements in array, got {}", expected, got)]
+#[derive(Error, Debug)]
+pub enum ArrayError<T: Error + 'static> {
+    #[error("`{0}`")]
+    Construct(#[source] T),
+    #[error("expected {expected} elements in array, got {got}")]
     Length { got: usize, expected: usize },
 }
 

--- a/src/kind/result.rs
+++ b/src/kind/result.rs
@@ -5,17 +5,18 @@ use crate::{
     ConstructResult, DeconstructResult, Kind,
 };
 
-use failure::Fail;
 use futures::{SinkExt, StreamExt};
+use std::error::Error;
+use thiserror::Error;
 
 use super::WrappedError;
 
-#[derive(Fail, Debug)]
-pub enum ResultError<T: Fail, E: Fail> {
-    #[fail(display = "{}", _0)]
-    Ok(#[fail(cause)] T),
-    #[fail(display = "{}", _0)]
-    Err(#[fail(cause)] E),
+#[derive(Error, Debug)]
+pub enum ResultError<T: Error + 'static, E: Error + 'static> {
+    #[error("`{0}`")]
+    Ok(#[source] T),
+    #[error("`{0}`")]
+    Err(#[source] E),
 }
 
 #[kind]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ macro_rules! log {
 
 #[cfg(all(feature = "core", target_arch = "wasm32"))]
 use {
-    core::pin::Pin,
+    ::core::pin::Pin,
     futures::task::{Context, Poll},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ pub mod reflect;
 pub mod replicate;
 
 use ::core::any::Any;
+use std::error::Error;
 use downcast_rs::{impl_downcast, Downcast};
 use erased_serde::Serialize as ErasedSerialize;
-use failure::Fail;
 use futures::Future;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -159,7 +159,7 @@ pub trait Kind: Any + Sized + Sync + Send + Unpin + 'static {
     /// from deconstruction.
     type ConstructItem: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static;
     /// The failure condition of constructing a concrete type from communicated data.
-    type ConstructError: Fail;
+    type ConstructError: Error + Sync + Send + 'static;
     /// The concrete future type returned by the construction process.
     type ConstructFuture: Future<Output = ConstructResult<Self>> + Sync + Send + 'static;
 
@@ -174,7 +174,7 @@ pub trait Kind: Any + Sized + Sync + Send + Unpin + 'static {
     /// to deconstruction.
     type DeconstructItem: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static;
     /// The failure condition of constructing a concrete type from communicated data.
-    type DeconstructError: Fail;
+    type DeconstructError: Error + Sync + Send + 'static;
     /// The concrete future type returned by the deconstruction process. This is
     /// used to only to communicate failure of deconstruction and does not return
     /// a value.
@@ -224,7 +224,7 @@ macro_rules! log {
 
 #[cfg(all(feature = "core", target_arch = "wasm32"))]
 use {
-    ::core::pin::Pin,
+    core::pin::Pin,
     futures::task::{Context, Poll},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,11 @@ pub mod reflect;
 pub mod replicate;
 
 use ::core::any::Any;
-use std::error::Error;
 use downcast_rs::{impl_downcast, Downcast};
 use erased_serde::Serialize as ErasedSerialize;
 use futures::Future;
 use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
 
 /// Generates an implementation of `Kind` for trait objects.
 ///
@@ -159,7 +159,7 @@ pub trait Kind: Any + Sized + Sync + Send + Unpin + 'static {
     /// from deconstruction.
     type ConstructItem: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static;
     /// The failure condition of constructing a concrete type from communicated data.
-    type ConstructError: Error + Sync + Send + 'static;
+    type ConstructError: ErrorBound;
     /// The concrete future type returned by the construction process.
     type ConstructFuture: Future<Output = ConstructResult<Self>> + Sync + Send + 'static;
 
@@ -174,7 +174,7 @@ pub trait Kind: Any + Sized + Sync + Send + Unpin + 'static {
     /// to deconstruction.
     type DeconstructItem: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static;
     /// The failure condition of constructing a concrete type from communicated data.
-    type DeconstructError: Error + Sync + Send + 'static;
+    type DeconstructError: ErrorBound;
     /// The concrete future type returned by the deconstruction process. This is
     /// used to only to communicate failure of deconstruction and does not return
     /// a value.
@@ -194,6 +194,11 @@ pub trait Kind: Any + Sized + Sync + Send + Unpin + 'static {
 /// An erased representation of any serializable type used in communication
 /// by `Kind`.
 pub(crate) trait SerdeAny: erased_serde::Serialize + Downcast + Sync + Send {}
+
+#[doc(hidden)]
+pub trait ErrorBound: Error + Sync + Send + 'static {}
+
+impl<T: Error + Sync + Send + 'static> ErrorBound for T {}
 
 impl_downcast!(SerdeAny);
 


### PR DESCRIPTION
Depending on failure on longer makes sense now that std::error::Error has the `source` method

Also, error passthrough in Flatten is necessary for proper error handling